### PR TITLE
Add mandatory field validation and refactor error handling

### DIFF
--- a/internal/app/run/workerpool.go
+++ b/internal/app/run/workerpool.go
@@ -46,11 +46,10 @@ func (w *WorkerPool) work(errCh chan<- error) {
 	defer w.wg.Done()
 
 	for in := range(w.inCh) {
-		txt, err := w.client.GetSecurityTxt(in)
-		if err != nil {
-			errCh <- err
-			return
-		}
+		// For now, errCh is for fatal errors. The following function
+		// does not have those - we will deal with this error when we
+		// implement counters, or a "rejected domains" list, or something.
+		txt, _ := w.client.GetSecurityTxt(in)
 
 		if txt != nil {
 			w.outCh <- txt

--- a/internal/app/run/writer.go
+++ b/internal/app/run/writer.go
@@ -39,6 +39,11 @@ func (w *Writer) Start(errCh chan<- error) error {
 
 		count := 0
 		for txt := range(w.inCh) {
+			if err := txt.Validate(); err != nil {
+				log.Info().Str("domain", txt.Domain).Err(err).Msg("invalid security.txt")
+				continue
+			}
+
 			log.Info().Str("domain", txt.Domain).Msg("security.txt found")
 
 			if txt.ParseErrors() != nil {

--- a/internal/pkg/discloseio/discloseio.go
+++ b/internal/pkg/discloseio/discloseio.go
@@ -67,7 +67,7 @@ func FromSecurityTxt(txt *securitytxt.SecurityTxt) *Fields {
 		}
 	}
 
-	if len(txt.Contact) > 0 || f.ContactURL == "" {
+	if len(txt.Contact) > 0 && f.ContactURL == "" {
 		f.ContactURL = txt.Contact[0]
 	}
 

--- a/pkg/securitytxt/domain.go
+++ b/pkg/securitytxt/domain.go
@@ -94,13 +94,13 @@ func (c *DomainClient) GetSecurityTxt(domain string) (*SecurityTxt, error) {
 	t, err := New(body.body)
 	if err != nil {
 		log.Info().Str("domain", strippedDomain).Err(err).Msg("error parsing security.txt")
-		return nil, nil
+		return nil, err
 	}
 
 	t.Domain = strippedDomain
 	t.RetrievedFrom = body.url
 	if body.err != nil {
-		t.addHTTPError(body.err)
+		t.addError(body.err)
 	}
 	return t, nil
 }
@@ -161,7 +161,7 @@ func (c *DomainClient) GetBody(url string) ([]byte, error) {
 */
 	contentType := resp.Header.Get("Content-Type")
 	if contentType != "text/plain; charset=utf/8" {
-		err = fmt.Errorf(contentTypeErrorMsg, contentType)
+		err = NewContentTypeError(contentType)
 	}
 
 	return body, err
@@ -189,7 +189,7 @@ func checkRedirect(req *http.Request, via []*http.Request) error {
 	fromHost := baseDomain(from.URL.Hostname())
 	toHost := baseDomain(req.URL.Hostname())
 	if fromHost != toHost {
-		return fmt.Errorf("redirect from %s to %s, prohibiting redirect to different hostname", fromHost, toHost)
+		return NewRedirectError(fromHost, toHost)
 	}
 
 	return nil

--- a/pkg/securitytxt/errors.go
+++ b/pkg/securitytxt/errors.go
@@ -1,40 +1,132 @@
 package securitytxt
 
 import (
+	"errors"
 	"fmt"
 )
 
-const (
-	separatorErrorMsg = "no ':' found to separate field-name and value, as per section 3.6.8 of RFC5322"
-	fieldNameErrorMsg = "field-name should be printable US-ASCII except space and :, as per section 3.6.8 of RFC5322"
-	valueErrorMsg = "value should be printable US-ASCII except space, as per 'unstructured' syntax in section 3.2.5 of RFC5322"
-	unknownFieldErrorMsg = "unexpected field-name '%s', as per section 3.5 of draft-foudil-securitytxt-09"
-	emptyValueErrorMsg = "value cannot be empty"
-	multipleValueErrorMsg = "multiple values for field '%s', expecting one value as per section 3.5 of draft-foudil-securitytxt-09"
-	invalidTimeErrorMsg = "invalid time in field '%s' according to section 3.3 of RFC5322: %s"
-	acknowledgmentsErrorMsg = "invalid field name 'acknowledgements', should be 'acknowledgments' as per section 3.5.1 of draft-foudil-securitytxt-09"
-	contentTypeErrorMsg = "invalid Content-Type of '%s', expecting 'text/plain; charset=utf-8' as per section 3 of draft-foudil-securitytxt-09"
-	missingContactErrorMsg = "Mandatory field 'Contact' not present as per section 3.5.3 of draft-foudil-securitytxt-09"
-)
+const SECURITYTXTSPEC = "draft-foudil-securitytxt-09"
 
+// Wrap error with some context
 type SyntaxError struct {
 	lineNo int
 	line string
-	msg string
-}
-
-func (e SyntaxError) Error() string {
-	return fmt.Sprintf("Error in line %d: %s", e.lineNo, e.msg)
-}
-
-type HTTPError struct {
 	err error
 }
 
-func (e HTTPError) Error() string {
+func (e SyntaxError) Error() string {
+	return fmt.Sprintf("Error in line %d: %s", e.lineNo, e.err.Error())
+}
+
+func (e SyntaxError) Unwrap() error {
+	return e.err
+}
+
+// Generic error wrapper to make other error types with
+type ErrorWrapper struct {
+	err error
+}
+
+func (e ErrorWrapper) Error() string {
 	return e.err.Error()
 }
 
-func (e HTTPError) Unwrap() error {
+func (e ErrorWrapper) Unwrap() error {
 	return e.err
+}
+
+// Errors during parsing - basic structure of security.txt is incorrect
+var (
+	AcknowledgmentsError = errors.New("invalid field name 'acknowledgements', should be 'acknowledgments' as per section 3.5.1 of " + SECURITYTXTSPEC)
+	EmptyValueError = errors.New("value cannot be empty")
+	FieldNameError = errors.New("field-name should be printable US-ASCII except space and :, as per section 3.6.8 of RFC5322")
+	SeparatorError = errors.New("no ':' found to separate field-name and value, as per section 3.6.8 of RFC5322")
+	ValueError = errors.New("value should be printable US-ASCII except space, as per 'unstructured' syntax in section 3.2.5 of RFC5322")
+)
+
+func NewAcknowledgmentsError() ParseError { return NewParseError(AcknowledgmentsError) }
+func NewEmptyValueError() ParseError { return NewParseError(EmptyValueError) }
+func NewFieldNameError() ParseError { return NewParseError(FieldNameError) }
+func NewSeparatorError() ParseError { return NewParseError(SeparatorError) }
+func NewValueError() ParseError { return NewParseError(ValueError) }
+
+type ParseError struct {
+	ErrorWrapper
+}
+
+func NewParseError(err error) ParseError {
+	return ParseError{ErrorWrapper{err}}
+}
+
+// Validation errors
+var (
+	MissingContactError = errors.New("Mandatory field 'Contact' not present as per section 3.5.3 of " + SECURITYTXTSPEC)
+)
+
+func NewMissingContactError() ValidationError { return NewValidationError(MissingContactError) }
+
+type ValidationError struct {
+	ErrorWrapper
+}
+
+func NewValidationError(err error) ValidationError {
+	return ValidationError{ErrorWrapper{err}}
+}
+
+// Errors during HTTP retrieval
+const (
+	contentTypeErrorMsg = "invalid Content-Type of '%s', expecting 'text/plain; charset=utf-8' as per section 3 of " + SECURITYTXTSPEC
+	redirectErrorMsg = "redirect from %s to %s, prohibiting redirect to different hostname"
+)
+
+type ContentTypeError struct {
+	contentType string
+}
+
+func NewContentTypeError(contentType string) HTTPError {
+	return NewHTTPError(ContentTypeError{contentType})
+}
+
+func (e ContentTypeError) Error() string {
+	return fmt.Sprintf(contentTypeErrorMsg, e.contentType)
+}
+
+type RedirectError struct {
+	from, to string
+}
+
+func NewRedirectError(from, to string) HTTPError {
+	return NewHTTPError(RedirectError{from, to})
+}
+
+func (e RedirectError) Error() string {
+	return fmt.Sprintf(redirectErrorMsg, e.from, e.to)
+}
+
+type HTTPError struct {
+	ErrorWrapper
+}
+
+func NewHTTPError(err error) HTTPError {
+	return HTTPError{ErrorWrapper{err}}
+}
+
+// Errors with field names or values
+const (
+	invalidTimeErrorMsg = "invalid time in field '%s' according to section 3.3 of RFC5322"
+	multipleValueErrorMsg = "multiple values for field '%s', expecting one value as per section 3.5 of " + SECURITYTXTSPEC
+	unknownFieldErrorMsg = "unexpected field-name '%s', as per section 3.5 of " + SECURITYTXTSPEC
+)
+
+func NewInvalidTimeError(f *Field, err error) FieldError { return FieldError{f, fmt.Sprintf("%S: %s", invalidTimeErrorMsg, err.Error())} }
+func NewMultipleValueError(f *Field) FieldError { return FieldError{f, multipleValueErrorMsg} }
+func NewUnknownFieldError(f *Field) FieldError { return FieldError{f, unknownFieldErrorMsg} }
+
+type FieldError struct {
+	field *Field
+	msg string
+}
+
+func (e FieldError) Error() string {
+	return fmt.Sprintf(e.msg, e.field.Key)
 }

--- a/pkg/securitytxt/errors.go
+++ b/pkg/securitytxt/errors.go
@@ -14,6 +14,7 @@ const (
 	invalidTimeErrorMsg = "invalid time in field '%s' according to section 3.3 of RFC5322: %s"
 	acknowledgmentsErrorMsg = "invalid field name 'acknowledgements', should be 'acknowledgments' as per section 3.5.1 of draft-foudil-securitytxt-09"
 	contentTypeErrorMsg = "invalid Content-Type of '%s', expecting 'text/plain; charset=utf-8' as per section 3 of draft-foudil-securitytxt-09"
+	missingContactErrorMsg = "Mandatory field 'Contact' not present as per section 3.5.3 of draft-foudil-securitytxt-09"
 )
 
 type SyntaxError struct {

--- a/pkg/securitytxt/field.go
+++ b/pkg/securitytxt/field.go
@@ -1,0 +1,6 @@
+package securitytxt
+
+type Field struct {
+	Key string
+	Value string
+}

--- a/pkg/securitytxt/parser.go
+++ b/pkg/securitytxt/parser.go
@@ -23,13 +23,13 @@ func Parse(in []byte, txt *SecurityTxt) error {
 		}
 
 		// Extact and check field-name and value
-		fieldName, value, errMsg := getFieldValue(line)
+		field, errMsg := getFieldValue(line)
 		if errMsg != "" {
 			txt.addError(lineNo, line, errMsg)
 			continue
 		}
 
-		errMsg = txt.AssignField(fieldName, value)
+		errMsg = txt.AssignField(field)
 		if errMsg != "" {
 			txt.addError(lineNo, line, errMsg)
 			continue
@@ -43,31 +43,30 @@ func Parse(in []byte, txt *SecurityTxt) error {
 	return nil
 }
 
-func getFieldValue(line string) (fieldName, value, errMsg string) {
+func getFieldValue(line string) (*Field, string) {
 	// RFC5322 3.6.8
 	split := strings.SplitN(line, ":", 2)
 	if len(split) != 2 {
-		errMsg = separatorErrorMsg
-		return
+		return nil, separatorErrorMsg
 	}
 
 	// Printable US-ASCII followed by optional white space; case insensitive.
-	fieldName = strings.ToLower(strings.TrimRightFunc(split[0], unicode.IsSpace))
-	value = strings.TrimSpace(split[1])
+	field := &Field{
+		Key: strings.ToLower(strings.TrimRightFunc(split[0], unicode.IsSpace)),
+		Value: strings.TrimSpace(split[1]),
+	}
 
 	// Check if field name is printable US-ASCII except space (VCHAR)
-	if strings.IndexFunc(fieldName, isNotUSASCII) != -1 {
-		errMsg = fieldNameErrorMsg
-		return
+	if strings.IndexFunc(field.Key, isNotUSASCII) != -1 {
+		return field, fieldNameErrorMsg
 	}
 
 	// Check if value is printable US-ASCII except space (VCHAR)
-	if strings.IndexFunc(value, isNotUSASCII) != -1 {
-		errMsg = valueErrorMsg
-		return
+	if strings.IndexFunc(field.Value, isNotUSASCII) != -1 {
+		return field, valueErrorMsg
 	}
 
-	return
+	return nil, ""
 }
 
 func isNotUSASCII(r rune) bool {
@@ -78,38 +77,38 @@ func isNotUSASCII(r rune) bool {
 	return false
 }
 
-func assignListValue(fieldName string, list *[]string, value string) (errMsg string) {
-	*list = append(*list, value)
+func assignListValue(list *[]string, field *Field) (errMsg string) {
+	*list = append(*list, field.Value)
 	return
 }
 
-func assignStringValue(fieldName string, str *string, value string) (errMsg string) {
+func assignStringValue(str *string, field *Field) (errMsg string) {
 	if *str != "" {
-		return fmt.Sprintf(multipleValueErrorMsg, fieldName)
+		return fmt.Sprintf(multipleValueErrorMsg, field.Key)
 	}
 
-	*str = value
+	*str = field.Value
 	return
 }
 
-func assignTimeValue(fieldName string, t *time.Time, value string) (errMsg string) {
+func assignTimeValue(t *time.Time, field *Field) (errMsg string) {
 	if !t.IsZero() {
-		return fmt.Sprintf(multipleValueErrorMsg, fieldName)
+		return fmt.Sprintf(multipleValueErrorMsg, field.Key)
 	}
 
 	var err error
 
 	// Check if we start with day number, else assume day name
-	if unicode.IsDigit(rune(value[0])) {
+	if unicode.IsDigit(rune(field.Value[0])) {
 		// "02 Jan 06 15:04 -0700"
-		*t, err = time.Parse(time.RFC822Z, value)
+		*t, err = time.Parse(time.RFC822Z, field.Value)
 	} else {
 		// "Mon, 02 Jan 2006 15:04:05 -0700" 
-		*t, err = time.Parse(time.RFC1123Z, value)
+		*t, err = time.Parse(time.RFC1123Z, field.Value)
 	}
 
 	if err != nil {
-		return fmt.Sprintf(invalidTimeErrorMsg, fieldName, err.Error())
+		return fmt.Sprintf(invalidTimeErrorMsg, field.Key, err.Error())
 	}
 	return
 }

--- a/pkg/securitytxt/securitytxt.go
+++ b/pkg/securitytxt/securitytxt.go
@@ -92,6 +92,11 @@ func (t *SecurityTxt) AssignField(field *Field) (errMsg string) {
 
 // TODO: Deeper verification to check if everything is exactly to spec
 func (t *SecurityTxt) Validate() error {
+	//  The "Contact" field MUST always be present in a security.txt file.
+	if len(t.Contact) == 0 {
+		return fmt.Errorf(missingContactErrorMsg)
+	}
+
 	return nil
 }
 

--- a/pkg/securitytxt/securitytxt.go
+++ b/pkg/securitytxt/securitytxt.go
@@ -55,38 +55,38 @@ func New(in []byte) (*SecurityTxt, error) {
 	return txt, nil
 }
 
-func (t *SecurityTxt) AssignField(fieldName, value string) (errMsg string) {
+func (t *SecurityTxt) AssignField(field *Field) (errMsg string) {
 	// I've thought about doing this by automatically finding the right
 	// fields in the SecurityTxt struct with reflect, but there's no
 	// need to be that flexible, it's slower and it also hurts my head.
 
-	if value == "" {
+	if field.Value == "" {
 		return emptyValueErrorMsg
 	}
 
 	// fieldName is lower case
-	switch fieldName {
+	switch field.Key {
 	case "acknowledgments":
-		return assignListValue(fieldName, &t.Acknowledgments, value)
+		return assignListValue(&t.Acknowledgments, field)
 	case "acknowledgements":
-		assignListValue(fieldName, &t.Acknowledgments, value)
+		assignListValue(&t.Acknowledgments, field)
 		return acknowledgmentsErrorMsg
 	case "canonical":
-		return assignListValue(fieldName, &t.Canonical, value)
+		return assignListValue(&t.Canonical, field)
 	case "contact":
-		return assignListValue(fieldName, &t.Contact, value)
+		return assignListValue(&t.Contact, field)
 	case "encryption":
-		return assignListValue(fieldName, &t.Encryption, value)
+		return assignListValue(&t.Encryption, field)
 	case "expires":
-		return assignTimeValue(fieldName, &t.Expires, value)
+		return assignTimeValue(&t.Expires, field)
 	case "hiring":
-		return assignListValue(fieldName, &t.Hiring, value)
+		return assignListValue(&t.Hiring, field)
 	case "policy":
-		return assignListValue(fieldName, &t.Policy, value)
+		return assignListValue(&t.Policy, field)
 	case "preferred-languages":
-		return assignStringValue(fieldName, &t.PreferredLanguages, value)
+		return assignStringValue(&t.PreferredLanguages, field)
 	default:
-		return fmt.Sprintf(unknownFieldErrorMsg, fieldName)
+		return fmt.Sprintf(unknownFieldErrorMsg, field.Key)
 	}
 }
 


### PR DESCRIPTION
When no `Contact` field was found, we still tried to use the first list item - silly logic error. Fixes this fixes the panic. On top, we're adding validation of the existence of mandatory fields, so we don't output json without e.g., a contact field.

Overhauling error handling: we now pass errors instead of just the strings and wrap them so we could detect easily what error exactly was thrown, if needed. We also bail on a domain on the first parse error - turns out often we get redirected to a login page, or get a fancy 404 page that is served with a 200.