### PR TITLE
Handle hostnames ending in "." and add `--strict-redirect`

### DIFF
--- a/cmd/diosts/commands/root.go
+++ b/cmd/diosts/commands/root.go
@@ -30,6 +30,12 @@ func init() {
 		run.DefaultConfig.NumThreads,
 		"Number of concurrent scraping threads",
 	)
+
+	rootCmd.Flags().BoolVar(&runConfig.SecurityTxt.StrictRedirect,
+		"strict-redirect",
+		false,
+		"Only allow redirects to same base domain",
+	)
 }
 
 func initApp() {

--- a/pkg/securitytxt/config.go
+++ b/pkg/securitytxt/config.go
@@ -9,6 +9,7 @@ type Config struct {
 	RequestTimeout time.Duration
 	TLSHandshakeTimeout time.Duration
 	Insecure bool
+	StrictRedirect bool
 }
 
 var DefaultConfig = Config{
@@ -16,6 +17,7 @@ var DefaultConfig = Config{
 	RequestTimeout: 10 * time.Second,
 	TLSHandshakeTimeout: 5 * time.Second,
 	Insecure: false,
+	StrictRedirect: false,
 }
 
 func NewConfig() *Config {

--- a/pkg/securitytxt/domain.go
+++ b/pkg/securitytxt/domain.go
@@ -197,6 +197,11 @@ func checkRedirect(req *http.Request, via []*http.Request) error {
 
 // Get the base domain name
 func baseDomain(domain string) string {
+	// Remove trailing "." - technically valid, but not needed in this case
+	if domain[len(domain) - 1] == byte('.') {
+		domain = domain[:len(domain) - 2]
+	}
+
 	splits := strings.Split(domain, ".")
 
 	// This is just weird, but ok - probably ipv6 address

--- a/pkg/securitytxt/domain.go
+++ b/pkg/securitytxt/domain.go
@@ -171,7 +171,7 @@ func (c *DomainClient) GetBody(url string) ([]byte, error) {
 // Make sure we don't leave this domain - always log something
 func (c *DomainClient) checkRedirect(req *http.Request, via []*http.Request) error {
 	from := via[len(via) - 1]
-	log.Debug().Str("from", from.URL.String()).Str("to", req.URL.String()).Msg("redirecting")
+	log.Info().Str("from", from.URL.String()).Str("to", req.URL.String()).Msg("redirecting")
 
 	if c.Config.StrictRedirect {
 		fromHost := baseDomain(from.URL.Hostname())

--- a/pkg/securitytxt/domain.go
+++ b/pkg/securitytxt/domain.go
@@ -57,8 +57,12 @@ func NewDomainClient(config *Config) (*DomainClient, error) {
 		KeepAlive: -1,
 	}
 
+	c := &DomainClient{
+		Config: config,
+	}
+
 	client := &http.Client{
-		CheckRedirect: checkRedirect,
+		CheckRedirect: c.checkRedirect,
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: config.Insecure,
@@ -71,10 +75,7 @@ func NewDomainClient(config *Config) (*DomainClient, error) {
 		Timeout: config.RequestTimeout,
 	}
 
-	c := &DomainClient{
-		Config: config,
-		client: client,
-	}
+	c.client = client
 
 	return c, nil
 }
@@ -167,6 +168,22 @@ func (c *DomainClient) GetBody(url string) ([]byte, error) {
 	return body, err
 }
 
+// Make sure we don't leave this domain - always log something
+func (c *DomainClient) checkRedirect(req *http.Request, via []*http.Request) error {
+	from := via[len(via) - 1]
+	log.Debug().Str("from", from.URL.String()).Str("to", req.URL.String()).Msg("redirecting")
+
+	if c.Config.StrictRedirect {
+		fromHost := baseDomain(from.URL.Hostname())
+		toHost := baseDomain(req.URL.Hostname())
+		if fromHost != toHost {
+			return NewRedirectError(fromHost, toHost)
+		}
+	}
+
+	return nil
+}
+
 // Get bare domain from input
 func stripDomain(domain string) (string) {
 	// Check for schema, strip if present
@@ -179,20 +196,6 @@ func stripDomain(domain string) (string) {
 	domain = splits[0]
 
 	return domain
-}
-
-// Make sure we don't leave this domain - always log something
-func checkRedirect(req *http.Request, via []*http.Request) error {
-	from := via[len(via) - 1]
-	log.Debug().Str("from", from.URL.String()).Str("to", req.URL.String()).Msg("redirecting")
-
-	fromHost := baseDomain(from.URL.Hostname())
-	toHost := baseDomain(req.URL.Hostname())
-	if fromHost != toHost {
-		return NewRedirectError(fromHost, toHost)
-	}
-
-	return nil
 }
 
 // Get the base domain name


### PR DESCRIPTION
Although technically valid, a hostname ending in "." would crash our code - fixed that.

Decided that by default we probably would want as many security.txt as possible, so added a `--strict-redirect` flag that replicates current behavior: disallow redirects to different base domains. Default behavior now is to allow that - but logging is elevated to info so we know there was a redirect.