### PR TITLE
Add new field security_txt_domain to output

### DIFF
--- a/internal/pkg/discloseio/discloseio.go
+++ b/internal/pkg/discloseio/discloseio.go
@@ -10,6 +10,7 @@ import (
 
 type Fields struct {
 	ProgramName string `json:"program_name,omitempty"`
+	SecurityTxtDomain string `json:"security_txt_domain,omitempty"`
 	PolicyURL string `json:"policy_url,omitempty"`
 	ContactURL string `json:"contact_url"`
 	LaunchDate *time.Time `json:"launch_date,omitempty"`
@@ -27,7 +28,7 @@ type Fields struct {
 
 func FromSecurityTxt(txt *securitytxt.SecurityTxt) *Fields {
 	f := &Fields{
-		ProgramName: txt.Domain,
+		SecurityTxtDomain: txt.Domain,
 		PreferredLanguages: txt.PreferredLanguages,
 	}
 


### PR DESCRIPTION
The domain for which `security.txt` was retrieved is now stored in the `security_txt_domain` field in the output. We used to use `program_name` for this, but this doesn't 100% overlap with the semantics used by disclose.io.